### PR TITLE
fix: routes config exception

### DIFF
--- a/addon/routes/fallback.js
+++ b/addon/routes/fallback.js
@@ -81,7 +81,7 @@ export default class FallbackRoute extends Route {
           .map(({ object: { value } }) => value);
 
     for (let type of rdfTypes) {
-      if (this.env.metis.routes[type]) {
+      if (this.env.metis.routes?.[type]) {
         this.replaceWith(this.env.metis.routes[type], { queryParams: { resource: model.directed.subject } });
         return;
       }


### PR DESCRIPTION
This prevents a possible exception when the metis.routes configuration object does not exist in the `config/environment.js` file.

I believe that object is optional since it's not documented in the Readme?