### PR TITLE
Appuniversum based fallback template

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,20 @@ Router.map(function() {
 Since `metisFallbackRoute` matches all paths, it's best to put the route at the bottom of your routes list.
 
 
+##### Import styles
+Import the metis styles in your app.scss file
+```scss
+// VARIABLES
+@import "appuniversum/s-colors.scss";
+@import "appuniversum/s-global";
+@import "appuniversum/s-utilities"
+
+// other imports
+
+@import "metis";
+```
+
+
 
 ## How-to guides
 ### Provide human-readable labels for URIs on the subject page

--- a/README.md
+++ b/README.md
@@ -92,21 +92,16 @@ Router.map(function() {
 
 Since `metisFallbackRoute` matches all paths, it's best to put the route at the bottom of your routes list.
 
+#### Setup styling
+ember-metis currently depends on [ember-appuniversum](https://appuniversum.github.io/ember-appuniversum/docs/outline/getting-started) and [ember-cli-sass](https://github.com/adopted-ember-addons/ember-cli-sass) for styling.
 
-##### Import styles
+After installing both packages, import the `metis` styling as follows in your `app.scss`
 Import the metis styles in your app.scss file
 ```scss
-// VARIABLES
-@import "appuniversum/s-colors.scss";
-@import "appuniversum/s-global";
-@import "appuniversum/s-utilities"
-
-// other imports
+// ... appuniversum imports
 
 @import "metis";
 ```
-
-
 
 ## How-to guides
 ### Provide human-readable labels for URIs on the subject page

--- a/addon/templates/fallback.hbs
+++ b/addon/templates/fallback.hbs
@@ -2,7 +2,7 @@
   <div class="au-o-region-large">
     <div class="au-o-layout">
       <div class="au-o-grid">
-        <div class="au-o-grid__item au-u-4-6@medium">
+        <div class="au-o-grid__item">
           <div class="au-o-region-large">
             <AuHeading class="au-u-margin-bottom-large">
               Detailpagina URI

--- a/addon/templates/fallback.hbs
+++ b/addon/templates/fallback.hbs
@@ -1,104 +1,179 @@
-<div class="container-flex--scroll">
-  <div class="page">
-    <div class="region">
-      <div class="layout layout--wide">
-        <div class="grid">
-          <div class="col--8-12 col--12-12--s">
-            <div class="u-hr region typography u-spacer">
-              <h1 class="h1 word-break--break-all smaller">Detailpagina URI</h1>
-              <p class="introduction">Deze pagina geeft informatie over het onderwerp <a href="{{this.model.subject}}"
-                                                                                        data-toggle="tooltip" title="Onderwerp" data-content="Onderwerp" data-placement="top"
-                                                                                        class="word-break--break-all">{{this.model.subject}}</a> weer, door relaties en details te tonen.</p>
-            </div>
+<div class="au-c-body-container au-c-body-container--scroll">
+  <div class="au-o-region-large">
+    <div class="au-o-layout">
+      <div class="au-o-grid">
+        <div class="au-o-grid__item au-u-4-6@medium">
+          <div class="au-o-region-large">
+            <AuHeading class="au-u-margin-bottom-large">
+              Detailpagina URI
+            </AuHeading>
 
-            <h2 class="h3 sans-serif u-spacer--tiny word-break--break-all">Eigenschappen en relaties</h2>
-            <p class="u-spacer">Directed links van het onderwerp.</p>
-            {{#if this.model.directed.triples}}
-              <div class="u-spacer--large">
-                <table about={{this.model.subject}} class="data-table data-table--zebra">
+            <p class="au-u-h3 metis-u-text-gray-600">
+              Deze pagina geeft informatie over het onderwerp
+              <a
+                href="{{this.model.directed.subject}}"
+                data-toggle="tooltip"
+                title="Onderwerp"
+                data-content="Onderwerp"
+                data-placement="top"
+                class="metis-u-word-break-all"
+              >
+                {{~this.model.directed.subject~}}
+              </a>
+              weer, door relaties en details te tonen.
+            </p>
+          </div>
+
+          <AuHr />
+
+          <AuHeading
+            @level="2"
+            @skin="2"
+            class="au-u-margin-top au-u-margin-bottom-small word-break--break-all"
+          >
+            Eigenschappen en relaties
+          </AuHeading>
+          <p class="au-u-margin-bottom">
+            Directed links van het onderwerp.
+          </p>
+
+          <div class="au-u-margin-bottom-large">
+            <div class="au-c-data-table">
+              <div class="au-c-data-table__wrapper">
+                <table class="au-c-data-table__table">
                   <thead>
-                    <tr>
-                      <th>Eigenschap{{!-- predicate --}}</th>
-                      <th>Onderwerp {{!-- object --}}</th>
+                    <tr class="au-c-data-table__header">
+                      <th class="data-table__header-title">
+                        Eigenschap{{! predicate }}
+                      </th>
+                      <th class="data-table__header-title">
+                        Onderwerp{{! object }}
+                      </th>
                     </tr>
                   </thead>
                   <tbody>
                     {{#if this.isLoadingDirected}}
                       <tr>
-                        <td>Aan het laden...</td>
+                        <td>
+                          Aan het laden...
+                        </td>
                         <td></td>
                       </tr>
                     {{else}}
                       {{#each this.model.directed.triples as |triple|}}
-
                         {{#if (eq triple.object.type "uri")}}
-                          <tr property={{triple.predicate}} resource={{triple.object.value}}>
+                          <tr
+                            property={{triple.predicate}}
+                            resource={{triple.object.value}}
+                          >
                             <td>
                               <Metis::DisplayUri @uri={{triple.predicate}} />
                             </td>
-                            <td>
+                            <td class="metis-u-word-break-all">
                               <Metis::DisplayUri @uri={{triple.object.value}} />
                             </td>
                           </tr>
                         {{else}}
-                          <tr property={{triple.predicate}} content={{triple.object.value}}>
+                          <tr
+                            property={{triple.predicate}}
+                            content={{triple.object.value}}
+                          >
                             <td>
                               <Metis::DisplayUri @uri={{triple.predicate}} />
                             </td>
-                            <td>
+                            <td class="metis-u-word-break-all">
                               {{triple.object.value}}
                             </td>
                           </tr>
                         {{/if}}
-                      {{/each}}
-                    {{/if}}
-                  </tbody>
-                </table>
-
-                <Metis::Pagination @count={{this.model.directed.count}} @size={{this.directedPageSize}}
-                  @page={{this.directedPageNumber}} @selectPage={{this.selectDirectedPage}} />
-              </div>
-            {{else}}
-              <p class="text-fade u-spacer--large">Geen directe links gevonden.</p>
-            {{/if}}
-
-            <h2 class="h3 sans-serif u-spacer--tiny">Verwijzingen</h2>
-            <p class="u-spacer">Inverse links naar het onderwerp.</p>
-            {{#if this.model.inverse.triples}}
-              <div class="u-spacer--large">
-                <table class="data-table data-table--zebra">
-                  <thead>
-                    <tr>
-                      <th>Eigenschap{{!-- predicate --}}</th>
-                      <th>Onderwerp {{!-- subject --}}</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {{#if this.isLoadingInverse}}
-                      <tr>
-                        <td>Aan het laden...</td>
-                        <td></td>
-                      </tr>
-                    {{else}}
-                      {{#each this.model.inverse.triples as |triple|}}
-                        <tr resource={{triple.subject}}>
-
-                          <td property={{triple.predicate}} resource={{triple.object}}>
-                            <Metis::DisplayUri @uri={{triple.predicate}} />
-                          </td>
-                          <td>
-                            <Metis::DisplayUri @uri={{triple.subject}} />
+                      {{else}}
+                        <tr>
+                          <td colspan="100%" class="au-c-data-table__message">
+                            <p>
+                              Geen directe links gevonden.
+                            </p>
                           </td>
                         </tr>
                       {{/each}}
                     {{/if}}
                   </tbody>
                 </table>
-                <Metis::Pagination @count={{this.model.inverse.count}} @size={{this.inversePageSize}}
-                  @page={{this.inversePageNumber}} @selectPage={{this.selectInversePage}} />
               </div>
-            {{else}}
-              <p class="text-fade u-spacer--large">Geen verwijzingen gevonden.</p>
+            </div>
+            {{#if this.model.directed.triples}}
+              <Metis::Pagination
+                @count={{this.model.directed.count}}
+                @size={{this.directedPageSize}}
+                @page={{this.directedPageNumber}}
+                @selectPage={{this.selectDirectedPage}}
+              />
+            {{/if}}
+          </div>
+
+          <AuHeading @level="2" @skin="2" class="au-u-margin-bottom-small">
+            Verwijzingen
+          </AuHeading>
+          <p class="au-u-margin-bottom">
+            Inverse links naar het onderwerp.
+          </p>
+
+          <div class="au-u-margin-bottom-large">
+            <div class="au-c-data-table">
+              <div class="au-c-data-table__wrapper">
+                <table class="au-c-data-table__table">
+                  <thead>
+                    <tr class="au-c-data-table__header">
+                      <th class="data-table__header-title">
+                        Eigenschap{{! predicate }}
+                      </th>
+                      <th class="data-table__header-title">
+                        Onderwerp{{! object }}
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {{#if this.isLoadingInverse}}
+                      <tr>
+                        <td>
+                          Aan het laden...
+                        </td>
+                        <td></td>
+                      </tr>
+                    {{else}}
+                      {{#each this.model.inverse.triples as |triple|}}
+                        <tr resource={{triple.subject}}>
+                          <td
+                            property={{triple.predicate}}
+                            resource={{triple.object}}
+                          >
+                            <Metis::DisplayUri @uri={{triple.predicate}} />
+                          </td>
+                          <td class="metis-u-word-break-all">
+                            <Metis::DisplayUri @uri={{triple.subject}} />
+                          </td>
+                        </tr>
+                      {{else}}
+                        <tr>
+                          <td colspan="100%" class="au-c-data-table__message">
+                            <p>
+                              Geen verwijzingen gevonden.
+                            </p>
+                          </td>
+                        </tr>
+                      {{/each}}
+                    {{/if}}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+
+            {{#if this.model.inverse.triples}}
+              <Metis::Pagination
+                @count={{this.model.inverse.count}}
+                @size={{this.inversePageSize}}
+                @page={{this.inversePageNumber}}
+                @selectPage={{this.selectInversePage}}
+              />
             {{/if}}
           </div>
         </div>
@@ -106,5 +181,3 @@
     </div>
   </div>
 </div>
-
-{{outlet}}

--- a/app/styles/metis.scss
+++ b/app/styles/metis.scss
@@ -1,0 +1,7 @@
+.metis-u-word-break-all {
+  word-break: break-word !important;
+}
+
+.metis-u-text-gray-600 {
+  color: $au-gray-600 !important;
+}

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "ember-truth-helpers": "^2.1.0",
     "recast": "^0.18.10"
   },
+  "peerDependencies": {
+    "@appuniversum/ember-appuniversum": "^0.1.3"
+  },
   "devDependencies": {
     "@appuniversum/appuniversum": "^0.0.14",
     "@appuniversum/ember-appuniversum": "0.0.31",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@ember/optional-features": "^1.3.0",
     "@glimmer/component": "^1.0.1",
     "@glimmer/tracking": "^1.0.0",
-    "@lblod/ember-vo-webuniversum": "^0.22.8",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
     "ember-cli": "~3.20.0",


### PR DESCRIPTION
This uses Appuniversum classes and components instead of the Webuniversum ones which allows us to not include Webuniversum in the mow-registry app just for the subject pages.

