### PR TITLE
Add json accept header to fetch calls

### DIFF
--- a/addon/routes/fallback.js
+++ b/addon/routes/fallback.js
@@ -1,7 +1,7 @@
 import Route from '@ember/routing/route';
 import { getOwner } from '@ember/application';
 import { inject as service } from '@ember/service';
-import fetch from 'fetch';
+import fetch, { Headers } from 'fetch';
 import buildUrl from 'build-url';
 import RSVP from 'rsvp';
 import { findRoute } from '../utils/class-route';
@@ -61,8 +61,16 @@ export default class FallbackRoute extends Route {
     });
 
     const response = await RSVP.hash({
-      directed: (await fetch(requestDirectedLinksUrl)).json(),
-      inverse: (await fetch(requestInverseLinksUrl)).json(),
+      directed: (await fetch(
+        requestDirectedLinksUrl, {
+          headers: new Headers({ "accept": "application/vnd.api+json" })
+        }
+      )).json(),
+      inverse: (await fetch(
+        requestInverseLinksUrl, {
+          headers: new Headers({ "accept": "application/vnd.api+json" })
+        }
+      )).json(),
     });
 
     return {

--- a/addon/services/resource-label.js
+++ b/addon/services/resource-label.js
@@ -1,6 +1,6 @@
 import Service, { inject } from '@ember/service';
 import buildUrl from 'build-url';
-import fetch from 'fetch';
+import fetch, { Headers } from 'fetch';
 
 export default class ResourceLabelService extends Service {
   @inject fastboot;
@@ -20,7 +20,10 @@ export default class ResourceLabelService extends Service {
         },
       });
 
-      const response = await fetch(fetchUrl);
+      const response = await fetch(
+        fetchUrl, {
+          headers: new Headers({ "accept": "application/vnd.api+json" })
+        });
       const body = await response.json();
 
       if (response.status == 200 && body.data && body.data.attributes) {


### PR DESCRIPTION
We request json bodies through manual fetch calls.  By setting the accept header it becomes easier for backend servers to reply with the desired content.  Within semantic.works this can simplify the dispatcher.ex configuration.