### PR TITLE
Styling fixes

### DIFF
--- a/addon/components/metis/pagination.hbs
+++ b/addon/components/metis/pagination.hbs
@@ -1,4 +1,4 @@
-<AuToolbar @size="medium" @border="top" @wowrap={{true}}>
+<AuToolbar @size="medium" @nowrap={{true}}>
   <div class="au-c-pagination">
     <div class="au-c-pagination__list-item">
       {{#if this.hasMultiplePages}}

--- a/addon/templates/fallback.hbs
+++ b/addon/templates/fallback.hbs
@@ -42,7 +42,7 @@
               {{t "fallback.sections.direct-triples.subheader"}}
             </p>
 
-            <div class="au-c-data-table__wrapper au-u-margin-bottom-large">
+            <div class="au-u-margin-bottom-large">
               {{#if this.model.directed.triples}}
                 <AuTable about={{this.model.directed.subject}}>
                 <:header>
@@ -111,7 +111,7 @@
             {{t "fallback.sections.inverse-triples.subheader"}}
           </p>
 
-          <div class="au-c-data-table__wrapper au-u-margin-bottom-large">
+          <div class="au-u-margin-bottom-large">
             {{#if this.model.inverse.triples}}
               <AuTable>
                 <:header>

--- a/tests/dummy/app/styles/_shame.scss
+++ b/tests/dummy/app/styles/_shame.scss
@@ -1,10 +1,4 @@
 /* ==========================================================================
    #SHAME
    Very specific css and temporary css.
-//    ========================================================================== */
-
-/* Make sure the sparql query table does not overflow and the buttons are positioned correctly */
-
-a.au-c-button:not(.au-c-button--secondary):not(.au-c-button--tertiary) {
-  color: $au-white;
-}
+   ========================================================================== */


### PR DESCRIPTION
This removes the "double" borders from the tables. There is still one double border remaining, but that's because of an issue in Appuniversum itself.