### PR TITLE
Add peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,10 @@
     "ember-truth-helpers": "^3.1.1",
     "recast": "^0.18.10"
   },
+  "peerDependencies": {
+    "@appuniversum/ember-appuniversum": "^2.18.0 || ^3.0.0",
+    "ember-cli-fastboot": "^4.1.2"
+  },
   "devDependencies": {
     "@appuniversum/ember-appuniversum": "^2.18.0",
     "@ember/optional-features": "^2.0.0",
@@ -51,6 +55,7 @@
     "broccoli-asset-rev": "^3.0.0",
     "ember-cli": "~4.8.0",
     "ember-cli-dependency-checker": "^3.3.1",
+    "ember-cli-fastboot": "^4.1.2",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-release": "^1.0.0-beta.2",
     "ember-cli-sass": "^10.0.1",

--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>Dummy</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 


### PR DESCRIPTION
We depend on the app having Appuniversum and FastBoot installed, so we should list them as peerDeps so we can define the ranges we are compatible with.