### PR TITLE
Add a local FastBoot setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# The environment which you also use as the proxy
+METIS_BACKEND_URL=""
+# The url that will be prefixed used as a prefix for all subject URIs (For example: `http://data.lblod.info/`)
+METIS_BASE_URL=""

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # misc
 /.env*
+!/.env.example
 /.pnp*
 /.sass-cache
 /.eslintcache

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "lint:js:fix": "eslint . --fix",
     "release": "release-it",
     "start": "ember serve",
+    "start:env": "dotenvx run -- npm run start:proxy",
+    "start:proxy": "ember serve --proxy $METIS_BACKEND_URL",
     "test": "npm-run-all --print-name \"lint\" \"test:*\"",
     "test:ember": "ember test",
     "test:ember-compatibility": "ember try:each"
@@ -54,6 +56,7 @@
   },
   "devDependencies": {
     "@appuniversum/ember-appuniversum": "^2.18.0",
+    "@dotenvx/dotenvx": "^0.15.4",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.8.1",
     "@embroider/test-setup": "^1.8.3",

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -8,7 +8,7 @@ module.exports = function (environment) {
     locationType: 'history',
     metis: {
       routes: {},
-      baseUrl: 'EMBER_METIS_BASE_URL',
+      baseUrl: '{{METIS_BASE_URL}}',
     },
     EmberENV: {
       FEATURES: {
@@ -29,6 +29,11 @@ module.exports = function (environment) {
     // ENV.APP.LOG_TRANSITIONS = true;
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
+
+    const { METIS_BASE_URL } = process.env;
+    if (METIS_BASE_URL) {
+      ENV.metis.baseUrl = METIS_BASE_URL;
+    }
   }
 
   if (environment === 'test') {

--- a/tests/dummy/config/fastboot.js
+++ b/tests/dummy/config/fastboot.js
@@ -1,0 +1,18 @@
+module.exports = function (/*environment*/) {
+  return {
+    buildSandboxGlobals(defaultGlobals) {
+      const devGlobals = {};
+
+      const { METIS_BACKEND_URL } = process.env;
+
+      if (METIS_BACKEND_URL) {
+        devGlobals.BACKEND_URL = METIS_BACKEND_URL;
+      }
+
+      return {
+        ...defaultGlobals,
+        ...devGlobals,
+      };
+    },
+  };
+};


### PR DESCRIPTION
This makes it easier to test the dummy app against a specific environment without having to deal with local untracked code changes.

A .env file can be created (starting from the .env.example file) to configure the needed env variables.

The `start:env` script can then be used to start the test app.