### PR TITLE
Shorter imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The `baseUrl` specifies the domain you want to serve subject pages for. I.e. the
 Finally, import and add the `metisFallbackRoute` util to your `router.js`
 
 ```javascript
-import metisFallbackRoute from 'ember-metis/utils/fallback-route';
+import { metisFallbackRoute } from 'ember-metis';
 
 Router.map(function() {
   // ... other routes here
@@ -100,7 +100,7 @@ Since `metisFallbackRoute` matches all paths, it's best to put the route at the 
 
 ## How-to guides
 ### Change the locale to nl-be
-Ember-metis uses [ember-intl](https://ember-intl.github.io/ember-intl/) for internationalization. By default the locale is set to `en-us` unless otherwise configured in the host app. To configure the locale in your host app, add the following application instance initializer:
+ember-metis uses [ember-intl](https://ember-intl.github.io/ember-intl/) for internationalization. By default the locale is set to `en-us` unless otherwise configured in the host app. To configure the locale in your host app, add the following application instance initializer:
 
 ```javascript
 // app/instance-initializers/locale.js
@@ -126,8 +126,7 @@ Before you generate your first custom route/template, import the `classRoute` ut
 ```javascript
 import EmberRouter from '@ember/routing/router';
 import config from './config/environment';
-import metisFallbackRoute from 'ember-metis/utils/fallback-route';
-import classRoute from 'ember-metis/utils/class-route';   // <---- Add this line
+import { classRoute, metisFallbackRoute } from 'ember-metis';   // <---- Edit this line
 
 export default class Router extends EmberRouter {
   location = config.locationType;

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,0 +1,2 @@
+export { default as classRoute } from 'ember-metis/utils/class-route';
+export { default as metisFallbackRoute } from 'ember-metis/utils/fallback-route';

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -1,7 +1,6 @@
 import EmberRouter from '@ember/routing/router';
 import config from 'dummy/config/environment';
-import metisFallbackRoute from 'ember-metis/utils/fallback-route';
-import classRoute from 'ember-metis/utils/class-route';
+import { classRoute, metisFallbackRoute } from 'ember-metis';
 
 export default class Router extends EmberRouter {
   location = config.locationType;

--- a/tests/unit/imports-test.js
+++ b/tests/unit/imports-test.js
@@ -1,0 +1,19 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { classRoute, metisFallbackRoute } from 'ember-metis';
+import classRouteFromPath from 'ember-metis/utils/class-route';
+import metisFallbackRouteFromPath from 'ember-metis/utils/fallback-route';
+
+module('imports', function (hooks) {
+  setupTest(hooks);
+
+  test('index imports work', function (assert) {
+    assert.ok(classRoute, 'classRoute import works');
+    assert.ok(metisFallbackRoute, 'metisFallbackRoute import works');
+  });
+
+  test('path imports work', function (assert) {
+    assert.ok(classRouteFromPath, 'classRoute import works');
+    assert.ok(metisFallbackRouteFromPath, 'metisFallbackRoute import works');
+  });
+});


### PR DESCRIPTION
This adds exports from the index.js file so the import paths are less verbose.

```diff
- import metisFallbackRoute from 'ember-metis/utils/fallback-route';
- import classRoute from 'ember-metis/utils/class-route';
+ import { classRoute, metisFallbackRoute } from 'ember-metis';
```