### PR TITLE
Dependency maintenance

### DIFF
--- a/addon/routes/fallback.js
+++ b/addon/routes/fallback.js
@@ -23,12 +23,18 @@ export default class FallbackRoute extends Route {
   };
 
   @service fastboot;
+  @service intl;
 
   constructor() {
     super(...arguments);
     this.env = getOwner(this).resolveRegistration('config:environment');
 
     this.templateName = this.env.metis.fallbackTemplate || 'fallback';
+
+    // Simply accessing the service works around this issue: https://github.com/ember-intl/ember-intl/issues/1826
+    // We do it in the addon code, so apps aren't forced to do it when they might not even be using ember-intl.
+    // TODO: remove this once the issue is fixed upstream
+    this.intl;
   }
 
   async model({

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "ember-cli-htmlbars": "^6.1.1",
     "ember-fetch": "^8.1.2",
     "ember-intl": "^6.0.0",
-    "ember-truth-helpers": "^3.1.1",
+    "ember-truth-helpers": "^4.0.3",
     "recast": "^0.18.10"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,9 @@
     "ember-truth-helpers": "^4.0.3",
     "recast": "^0.18.10"
   },
+  "dependenciesComments": {
+    "chalk": "chalk v5 is an esm-only package which we can't use in our node code since they are cjs modules"
+  },
   "peerDependencies": {
     "@appuniversum/ember-appuniversum": "^2.18.0 || ^3.0.0",
     "ember-cli-fastboot": "^4.1.2"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "ember-cli-babel": "^7.26.11",
     "ember-cli-htmlbars": "^6.1.1",
     "ember-fetch": "^8.1.2",
-    "ember-intl": "^5.7.2",
+    "ember-intl": "^6.0.0",
     "ember-truth-helpers": "^3.1.1",
     "recast": "^0.18.10"
   },


### PR DESCRIPTION
Some maintenance of the dependencies we ship to consumers.

Possibly "breaking" if apps are using ember-cli-dependency-lint, since this might cause multiple versions, but that's the life in the Ember world, so we don't consider this breaking by itself 😄.