### PR TITLE
rename `metisFallbackRoute` to `fallbackRoute`

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,19 +84,19 @@ let ENV = {
 
 The `baseUrl` specifies the domain you want to serve subject pages for. I.e. the base URL of your production environment.
 
-Finally, import and add the `metisFallbackRoute` util to your `router.js`
+Finally, import and add the `fallbackRoute` util to your `router.js`
 
 ```javascript
-import { metisFallbackRoute } from 'ember-metis';
+import { fallbackRoute } from 'ember-metis';
 
 Router.map(function() {
   // ... other routes here
 
-  metisFallbackRoute(this);
+  fallbackRoute(this);
 });
 ```
 
-Since `metisFallbackRoute` matches all paths, it's best to put the route at the bottom of your routes list.
+Since `fallbackRoute` matches all paths, it's best to put the route at the bottom of your routes list.
 
 ## How-to guides
 ### Change the locale to nl-be
@@ -126,7 +126,7 @@ Before you generate your first custom route/template, import the `classRoute` ut
 ```javascript
 import EmberRouter from '@ember/routing/router';
 import config from './config/environment';
-import { classRoute, metisFallbackRoute } from 'ember-metis';   // <---- Edit this line
+import { classRoute, fallbackRoute } from 'ember-metis';   // <---- Edit this line
 
 export default class Router extends EmberRouter {
   location = config.locationType;
@@ -136,7 +136,7 @@ export default class Router extends EmberRouter {
 Router.map(function() {
   // other routes
   this.route('view', function() { });  // <---- Add this line
-  metisFallbackRoute(this);
+  fallbackRoute(this);
 });
 ```
 

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,2 +1,2 @@
 export { default as classRoute } from 'ember-metis/utils/class-route';
-export { default as metisFallbackRoute } from 'ember-metis/utils/fallback-route';
+export { default as fallbackRoute } from 'ember-metis/utils/fallback-route';

--- a/addon/utils/fallback-route.js
+++ b/addon/utils/fallback-route.js
@@ -1,3 +1,3 @@
-export default function metisFallbackRoute(router) {
+export default function fallbackRoute(router) {
   router.route('fallback', { path: '/*path' });
 }

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -1,6 +1,6 @@
 import EmberRouter from '@ember/routing/router';
 import config from 'dummy/config/environment';
-import { classRoute, metisFallbackRoute } from 'ember-metis';
+import { classRoute, fallbackRoute } from 'ember-metis';
 
 export default class Router extends EmberRouter {
   location = config.locationType;
@@ -14,5 +14,5 @@ Router.map(function () {
     });
   });
 
-  metisFallbackRoute(this);
+  fallbackRoute(this);
 });

--- a/tests/unit/imports-test.js
+++ b/tests/unit/imports-test.js
@@ -1,19 +1,19 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import { classRoute, metisFallbackRoute } from 'ember-metis';
+import { classRoute, fallbackRoute } from 'ember-metis';
 import classRouteFromPath from 'ember-metis/utils/class-route';
-import metisFallbackRouteFromPath from 'ember-metis/utils/fallback-route';
+import fallbackRouteFromPath from 'ember-metis/utils/fallback-route';
 
 module('imports', function (hooks) {
   setupTest(hooks);
 
   test('index imports work', function (assert) {
     assert.ok(classRoute, 'classRoute import works');
-    assert.ok(metisFallbackRoute, 'metisFallbackRoute import works');
+    assert.ok(fallbackRoute, 'fallbackRoute import works');
   });
 
   test('path imports work', function (assert) {
     assert.ok(classRouteFromPath, 'classRoute import works');
-    assert.ok(metisFallbackRouteFromPath, 'metisFallbackRoute import works');
+    assert.ok(fallbackRouteFromPath, 'fallbackRoute import works');
   });
 });


### PR DESCRIPTION
Small amendment to #18 

This is shorter, consistent with the classRoute import, and the metis prefix is implied by the import path.

Apps can still rename the import if needed.