### PR TITLE
Fix Fastboot cookies

### DIFF
--- a/addon/routes/external.js
+++ b/addon/routes/external.js
@@ -40,17 +40,16 @@ export default class ExternalRoute extends Route {
     resource,
   }) {
     const subject = resource;
-    const backend = this.fastboot.isFastBoot ? window.BACKEND_URL : '/';
 
     const response = await RSVP.hash({
       directed: await fetchUriInfo(
-        backend,
+        this.fastboot,
         subject,
         directedPageNumber,
         directedPageSize
       ),
       inverse: await fetchUriInfo(
-        backend,
+        this.fastboot,
         subject,
         inversePageNumber,
         inversePageSize,

--- a/addon/routes/fallback.js
+++ b/addon/routes/fallback.js
@@ -42,17 +42,15 @@ export default class FallbackRoute extends Route {
     const prefix = this.env.metis.baseUrl;
     const subject = `${prefix}${path}`;
 
-    const backend = this.fastboot.isFastBoot ? window.BACKEND_URL : '/';
-
     const response = await RSVP.hash({
       directed: await fetchUriInfo(
-        backend,
+        this.fastboot,
         subject,
         directedPageNumber,
         directedPageSize
       ),
       inverse: await fetchUriInfo(
-        backend,
+        this.fastboot,
         subject,
         inversePageNumber,
         inversePageSize,

--- a/addon/utils/fetch-uri-info.js
+++ b/addon/utils/fetch-uri-info.js
@@ -8,7 +8,7 @@ export default async function fetchUriInfo(
   size,
   direction = 'direct'
 ) {
-  const baseUrl = this.fastboot.isFastBoot ? window.BACKEND_URL : '/';
+  const baseUrl = fastboot.isFastBoot ? window.BACKEND_URL : '/';
 
   const url = buildUrl(baseUrl, {
     path: `uri-info/${direction}`,

--- a/addon/utils/fetch-uri-info.js
+++ b/addon/utils/fetch-uri-info.js
@@ -2,12 +2,14 @@ import fetch, { Headers } from 'fetch';
 import buildUrl from 'build-url';
 
 export default async function fetchUriInfo(
-  baseUrl,
+  fastboot,
   subject,
   number,
   size,
   direction = 'direct'
 ) {
+  const baseUrl = this.fastboot.isFastBoot ? window.BACKEND_URL : '/';
+
   const url = buildUrl(baseUrl, {
     path: `uri-info/${direction}`,
     queryParams: {
@@ -19,7 +21,14 @@ export default async function fetchUriInfo(
 
   const response = await (
     await fetch(url, {
-      headers: new Headers({ accept: 'application/vnd.api+json' }),
+      headers: new Headers({
+        accept: 'application/vnd.api+json',
+        ...(fastboot.isFastBoot
+          ? {
+              Cookie: fastboot.request?.headers.get('Cookie'),
+            }
+          : {}),
+      }),
     })
   ).json();
 


### PR DESCRIPTION
Currently, when using Fastboot, user cookies are not passed in the `fetch` request. This means that, e.g., if only authenticated users have access to some data, the subject page will initially say "No data found" because of the unauthenticated Fastboot request, and once the page hydrates (through the browser request, which includes cookies by default), the page will render with the actual data.

This PR modifies the `fetchUriInfo` function to manually force attaching cookies in Fastboot, thereby making the behavior between Fastboot and browser consistent.

Additionally, it removes the `baseUrl` argument, since it can be calculated using the newly passed `fastboot` object.