### PR TITLE
Make support for fastboot optional

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,7 +22,25 @@ module.exports = {
   env: {
     browser: true,
   },
-  rules: {},
+  rules: {
+    'no-restricted-syntax': [
+      'error',
+      // Match `@service fastboot`
+      {
+        selector:
+          "Decorator[expression.name='service'][parent.key.name='fastboot']",
+        message: `Using \`@service fastboot\` should not be used as we can't guarantee the presence of a fastboot service.
+                  Use a dynamic getter to access the fastboot service instead.`,
+      },
+      // Match `@service('fastboot') ...`
+      {
+        selector:
+          "Decorator[expression.type='CallExpression'][expression.callee.name='service'] Literal[value='fastboot']",
+        message: `Using \`@service('fastboot')\` should not be used as we can't guarantee the presence of a fastboot service.
+                  Use a dynamic getter to access the fastboot service instead.`,
+      },
+    ],
+  },
   overrides: [
     // node files
     {

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ Next, make the service endpoints available in `./config/dispatcher/dispatcher.ex
   end
 
 ```
-#### Setup the frontend
-ember-metis requires [Ember FastBoot](https://github.com/ember-fastboot/ember-cli-fastboot). Install the addon in your application if it's not yet available:
+#### Using with `ember-cli-fastboot`
+ember-metis provides optional support for [Ember FastBoot](https://github.com/ember-fastboot/ember-cli-fastboot). Install the `ember-cli-fastboot` addon in your application if you want to use it.
 
 ```bash
 ember install ember-cli-fastboot

--- a/README.md
+++ b/README.md
@@ -48,13 +48,58 @@ Next, make the service endpoints available in `./config/dispatcher/dispatcher.ex
   end
 
 ```
-#### Using with `ember-cli-fastboot`
-ember-metis provides optional support for [Ember FastBoot](https://github.com/ember-fastboot/ember-cli-fastboot). Install the `ember-cli-fastboot` addon in your application if you want to use it.
+
+#### Setup the frontend
+##### Install Appuniversum
+ember-metis depends on components from the [ember-appuniversum addon](https://github.com/appuniversum/ember-appuniversum). Follow the [getting started guide](https://appuniversum.github.io/ember-appuniversum/?path=/story/outline-getting-started--page) to set that up first.
+
+##### Install ember-metis
+Install the ember-metis addon in your application.
+
+```bash
+npm install -D ember-metis
+```
+
+Add the following configuration to `./config/environment.js`:
+```javascript
+module.exports = function (environment) {
+  const ENV = {
+    // ... other config here ...
+    metis: {
+      baseUrl: "http://data.lblod.info/"
+    }
+  }
+}
+```
+
+The `baseUrl` specifies the domain you want to serve subject pages for. I.e. the base URL of your production environment.
+
+Finally, import and add the `fallbackRoute` util to your `router.js`
+
+```javascript
+import { fallbackRoute, externalRoute } from 'ember-metis';
+
+Router.map(function() {
+  // ... other routes here
+
+  externalRoute(this);
+  fallbackRoute(this);
+});
+```
+
+Since `fallbackRoute` matches all paths, it's best to put the route at the bottom of your routes list.
+
+### Optional: FastBoot support
+ember-metis provides optional support for [Ember FastBoot](https://github.com/ember-fastboot/ember-cli-fastboot). Skip this section if you don't need server-side rendering.
+
+#### Install FastBoot
+Install the `ember-cli-fastboot` addon in your application if you want to use it.
 
 ```bash
 ember install ember-cli-fastboot
 ```
 
+#### Configure FastBoot for ember-metis
 For local development using `ember serve` ember-metis requires `BACKEND_URL` as a sandbox global when running in fastboot mode. The value of `BACKEND_URL` must be the same URL you pass as proxy URL in `ember serve --proxy`. Typically `http://localhost/` (or `http://host` when serving the frontend from a Docker container using [eds](https://github.com/madnificent/docker-ember#eds)).
 
 If your app depends on Ember Data >= v4.12 you will need some additional sandbox globals to support `fetch` in Fastboot.
@@ -111,45 +156,6 @@ module.exports = function (environment) {
   }
 }
 ```
-
-#### Setup Appuniversum
-ember-metis depends on components from the [ember-appuniversum addon](https://github.com/appuniversum/ember-appuniversum). Follow the [getting started guide](https://appuniversum.github.io/ember-appuniversum/?path=/story/outline-getting-started--page) to set that up first.
-
-#### Install ember-metis
-Install the ember-metis addon in your application.
-
-```bash
-npm install -D ember-metis
-```
-
-Add the following configuration to `./config/environment.js`:
-```javascript
-module.exports = function (environment) {
-  const ENV = {
-    // ... other config here ...
-    metis: {
-      baseUrl: "http://data.lblod.info/"
-    }
-  }
-}
-```
-
-The `baseUrl` specifies the domain you want to serve subject pages for. I.e. the base URL of your production environment.
-
-Finally, import and add the `fallbackRoute` util to your `router.js`
-
-```javascript
-import { fallbackRoute, externalRoute } from 'ember-metis';
-
-Router.map(function() {
-  // ... other routes here
-
-  externalRoute(this);
-  fallbackRoute(this);
-});
-```
-
-Since `fallbackRoute` matches all paths, it's best to put the route at the bottom of your routes list.
 
 ## How-to guides
 ### Upgrade from 0.9.0

--- a/addon/components/metis/display-uri.js
+++ b/addon/components/metis/display-uri.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { getOwner } from '@ember/application';
+import { getOwner } from '../../utils/compat/get-owner';
 import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 

--- a/addon/controllers/external.js
+++ b/addon/controllers/external.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
-import { getOwner } from '@ember/application';
+import { getOwner } from '../utils/compat/get-owner';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 

--- a/addon/controllers/fallback.js
+++ b/addon/controllers/fallback.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
-import { getOwner } from '@ember/application';
+import { getOwner } from '../utils/compat/get-owner';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 

--- a/addon/routes/external.js
+++ b/addon/routes/external.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 import RSVP from 'rsvp';
 import { findRouteByType } from '../utils/class-route';
 import fetchUriInfo from '../utils/fetch-uri-info';
+import { getOwner } from '../utils/compat/get-owner';
 
 export default class ExternalRoute extends Route {
   queryParams = {
@@ -24,12 +25,15 @@ export default class ExternalRoute extends Route {
   };
 
   @service router;
-  @service fastboot;
   @service intl;
 
   constructor() {
     super(...arguments);
     this.templateName = 'external';
+  }
+
+  get fastboot() {
+    return getOwner(this).lookup('service:fastboot');
   }
 
   async model({

--- a/addon/routes/external.js
+++ b/addon/routes/external.js
@@ -32,6 +32,12 @@ export default class ExternalRoute extends Route {
     this.templateName = 'external';
   }
 
+  /**
+   * We are not sure the `fastboot` service is available in the host app,
+   * as using fastboot with this addon is optional.
+   * Instead of injecting the service through the `@service` decorator (which always expects the service to be present, else will throw an error),
+   * we lookup the service dynamically in a getter.
+   */
   get fastboot() {
     return getOwner(this).lookup('service:fastboot');
   }

--- a/addon/routes/fallback.js
+++ b/addon/routes/fallback.js
@@ -31,6 +31,12 @@ export default class FallbackRoute extends Route {
     this.templateName = this.env.metis.fallbackTemplate || 'fallback';
   }
 
+  /**
+   * We are not sure the `fastboot` service is available in the host app,
+   * as using fastboot with this addon is optional.
+   * Instead of injecting the service through the `@service` decorator (which always expects the service to be present, else will throw an error),
+   * we lookup the service dynamically in a getter.
+   */
   get fastboot() {
     return getOwner(this).lookup('service:fastboot');
   }

--- a/addon/routes/fallback.js
+++ b/addon/routes/fallback.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { getOwner } from '@ember/application';
+import { getOwner } from '../utils/compat/get-owner';
 import { inject as service } from '@ember/service';
 import RSVP from 'rsvp';
 import { findRouteByType } from '../utils/class-route';
@@ -22,7 +22,6 @@ export default class FallbackRoute extends Route {
   };
 
   @service router;
-  @service fastboot;
   @service intl;
 
   constructor() {
@@ -30,6 +29,10 @@ export default class FallbackRoute extends Route {
     this.env = getOwner(this).resolveRegistration('config:environment');
 
     this.templateName = this.env.metis.fallbackTemplate || 'fallback';
+  }
+
+  get fastboot() {
+    return getOwner(this).lookup('service:fastboot');
   }
 
   async model({

--- a/addon/services/resource-label.js
+++ b/addon/services/resource-label.js
@@ -1,26 +1,29 @@
-import Service, { inject } from '@ember/service';
+import Service from '@ember/service';
 import buildUrl from 'build-url';
 import fetch, { Headers } from 'fetch';
-
+import { getOwner } from '../utils/compat/get-owner';
 const SHOEBOX_KEY = 'resource-label-cache';
 export default class ResourceLabelService extends Service {
-  @inject fastboot;
   backend = '/';
   cache = {};
 
   constructor() {
     super(...arguments);
 
-    if (this.fastboot.isFastBoot) {
+    if (this.fastboot?.isFastBoot) {
       this.backend = window.BACKEND_URL;
     } else {
-      this.cache = this.fastboot.shoebox.retrieve(SHOEBOX_KEY) || {};
+      this.cache = this.fastboot?.shoebox.retrieve(SHOEBOX_KEY) || {};
     }
+  }
+
+  get fastboot() {
+    return getOwner(this).lookup('service:fastboot');
   }
 
   async fetchPrefLabel(uri) {
     const promise = this._fetchPrefLabel(uri);
-    if (this.fastboot.isFastBoot) {
+    if (this.fastboot?.isFastBoot) {
       this.fastboot.deferRendering(promise);
     }
 
@@ -53,7 +56,7 @@ export default class ResourceLabelService extends Service {
         };
       }
 
-      if (this.fastboot.isFastBoot) {
+      if (this.fastboot?.isFastBoot) {
         this.fastboot.shoebox.put(SHOEBOX_KEY, this.cache);
       }
     }

--- a/addon/services/resource-label.js
+++ b/addon/services/resource-label.js
@@ -17,6 +17,12 @@ export default class ResourceLabelService extends Service {
     }
   }
 
+  /**
+   * We are not sure the `fastboot` service is available in the host app,
+   * as using fastboot with this addon is optional.
+   * Instead of injecting the service through the `@service` decorator (which always expects the service to be present, else will throw an error),
+   * we lookup the service dynamically in a getter.
+   */
   get fastboot() {
     return getOwner(this).lookup('service:fastboot');
   }

--- a/addon/utils/compat/get-owner.js
+++ b/addon/utils/compat/get-owner.js
@@ -1,0 +1,11 @@
+import {
+  macroCondition,
+  dependencySatisfies,
+  importSync,
+} from '@embroider/macros';
+
+export const getOwner = macroCondition(
+  dependencySatisfies('ember-source', '>= 4.11'),
+)
+  ? importSync('@ember/owner').getOwner
+  : importSync('@ember/application').getOwner;

--- a/addon/utils/fetch-uri-info.js
+++ b/addon/utils/fetch-uri-info.js
@@ -8,7 +8,7 @@ export default async function fetchUriInfo(
   size,
   direction = 'direct',
 ) {
-  const baseUrl = fastboot.isFastBoot ? window.BACKEND_URL : '/';
+  const baseUrl = fastboot?.isFastBoot ? window.BACKEND_URL : '/';
 
   const url = buildUrl(baseUrl, {
     path: `uri-info/${direction}`,
@@ -23,7 +23,7 @@ export default async function fetchUriInfo(
     await fetch(url, {
       headers: new Headers({
         accept: 'application/vnd.api+json',
-        ...(fastboot.isFastBoot
+        ...(fastboot?.isFastBoot
           ? {
               Cookie: fastboot.request?.headers.get('Cookie'),
             }

--- a/package.json
+++ b/package.json
@@ -60,6 +60,11 @@
     "ember-cli-fastboot": "^4.1.2",
     "ember-source": ">= 4.0.0"
   },
+  "peerDependenciesMeta": {
+    "ember-cli-fastboot": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@appuniversum/ember-appuniversum": "^3.8.0",
     "@babel/eslint-parser": "^7.25.1",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.25.2",
+    "@embroider/macros": "^1.18.2",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
     "build-url": "^6.0.1",


### PR DESCRIPTION
### Overview
This PR ensures that this addon is also able to work installed in applications running without `ember-cli-fastboot`.

Additionally this PR also contains a compatibility layer for the `getOwner` function, which is imported from two different locations depending on the version of ember you are running.

### Reasoning
This PR allows this addon to be used with applications which do not require SSR. Additionally, fastboot is on its way out, and is no longer recommended. Vite SSR will be recommended as the SSR solution for ember in the future.

##### connected issues and PRs:
Example of `ember-metis` in an application without fastboot: https://github.com/lblod/frontend-mow-registry/pull/352

### How to test/reproduce
To test this PR, you'd ideally need to run it in 2 applications:
- one with fastboot (like the test-app included in this repository)
- one without fastboot
