### PR TITLE
support serviceBaseUrl and remove deprecated build-url package

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,27 @@ E.g.
     }
   }
 ```
+
+#### Service base URL (experimental)
+**Note: This configuration is typically not needed for standard semantic.works applications.**
+
+For custom deployment scenarios where backend services are not available at the standard paths, you can configure a custom service base URL:
+
+E.g.
+```javascript
+  metis: {
+    baseUrl: "http://data.lblod.info/",
+    serviceBase: "http://backend.example.com/"
+  }
+```
+
+The `serviceBase` specifies the base URL where the required backend services (uri-info and resource-labels) are available. This is useful when:
+- Services are deployed on a different domain than the frontend
+- Services are available under a custom path prefix
+- Running in non-standard deployment configurations
+
+For typical semantic.works applications using the standard stack, this configuration should not be necessary.
+
 ### Generators
 #### rdf-route
 Generate a custom route/controller/template per rdf:type using

--- a/addon/components/metis/display-uri.js
+++ b/addon/components/metis/display-uri.js
@@ -22,7 +22,11 @@ export default class MetisDisplayUriComponent extends Component {
     this.description = null;
 
     if (this.args.uri) {
-      const entry = await this.labelService.fetchPrefLabel(this.args.uri);
+      const serviceBase = this.config.metis?.serviceBase || '/';
+      const entry = await this.labelService.fetchPrefLabel(
+        this.args.uri,
+        serviceBase,
+      );
       this.externalPreflabel = entry.prefLabel;
       this.description = entry.description;
     }

--- a/addon/routes/external.js
+++ b/addon/routes/external.js
@@ -29,6 +29,7 @@ export default class ExternalRoute extends Route {
 
   constructor() {
     super(...arguments);
+    this.env = getOwner(this).resolveRegistration('config:environment');
     this.templateName = 'external';
   }
 
@@ -50,6 +51,10 @@ export default class ExternalRoute extends Route {
     resource,
   }) {
     const subject = resource;
+    const serviceBase =
+      this.env.metis.serviceBase === 'SERVICE_BASE'
+        ? '/'
+        : this.env.metis.serviceBase;
 
     const response = await RSVP.hash({
       directed: await fetchUriInfo(
@@ -57,6 +62,8 @@ export default class ExternalRoute extends Route {
         subject,
         directedPageNumber,
         directedPageSize,
+        'direct',
+        serviceBase,
       ),
       inverse: await fetchUriInfo(
         this.fastboot,
@@ -64,6 +71,7 @@ export default class ExternalRoute extends Route {
         inversePageNumber,
         inversePageSize,
         'inverse',
+        serviceBase,
       ),
     });
 

--- a/addon/routes/external.js
+++ b/addon/routes/external.js
@@ -51,10 +51,7 @@ export default class ExternalRoute extends Route {
     resource,
   }) {
     const subject = resource;
-    const serviceBase =
-      this.env.metis.serviceBase === 'SERVICE_BASE'
-        ? '/'
-        : this.env.metis.serviceBase;
+    const serviceBase = this.env.metis?.serviceBase || '/';
 
     const response = await RSVP.hash({
       directed: await fetchUriInfo(

--- a/addon/routes/fallback.js
+++ b/addon/routes/fallback.js
@@ -49,10 +49,7 @@ export default class FallbackRoute extends Route {
     inversePageSize,
   }) {
     const prefix = this.env.metis.baseUrl;
-    const serviceBase =
-      this.env.metis.serviceBase === '{{METIS_SERVICE_BASE}}'
-        ? '/'
-        : this.env.metis.serviceBase;
+    const serviceBase = this.env.metis?.serviceBase || '/';
     const subject = `${prefix}${path}`;
 
     const response = await RSVP.hash({

--- a/addon/routes/fallback.js
+++ b/addon/routes/fallback.js
@@ -49,6 +49,10 @@ export default class FallbackRoute extends Route {
     inversePageSize,
   }) {
     const prefix = this.env.metis.baseUrl;
+    const serviceBase =
+      this.env.metis.serviceBase === '{{METIS_SERVICE_BASE}}'
+        ? '/'
+        : this.env.metis.serviceBase;
     const subject = `${prefix}${path}`;
 
     const response = await RSVP.hash({
@@ -57,6 +61,8 @@ export default class FallbackRoute extends Route {
         subject,
         directedPageNumber,
         directedPageSize,
+        'direct',
+        serviceBase,
       ),
       inverse: await fetchUriInfo(
         this.fastboot,
@@ -64,6 +70,7 @@ export default class FallbackRoute extends Route {
         inversePageNumber,
         inversePageSize,
         'inverse',
+        serviceBase,
       ),
     });
 

--- a/addon/services/resource-label.js
+++ b/addon/services/resource-label.js
@@ -10,7 +10,8 @@ export default class ResourceLabelService extends Service {
     super(...arguments);
 
     if (this.fastboot?.isFastBoot) {
-      this.backend = (typeof window !== 'undefined' ? window.BACKEND_URL : null) || '/';
+      this.backend =
+        (typeof window !== 'undefined' ? window.BACKEND_URL : null) || '/';
     } else {
       this.cache = this.fastboot?.shoebox.retrieve(SHOEBOX_KEY) || {};
     }
@@ -37,7 +38,10 @@ export default class ResourceLabelService extends Service {
 
   async _fetchPrefLabel(uri) {
     if (!this.cache[uri]) {
-      const baseUrl = (this.backend && this.backend.endsWith('/')) ? this.backend.slice(0, -1) : (this.backend || '/');
+      const baseUrl =
+        this.backend && this.backend.endsWith('/')
+          ? this.backend.slice(0, -1)
+          : this.backend || '/';
 
       // Fallback for URLSearchParams in FastBoot environment
       let params;

--- a/addon/services/resource-label.js
+++ b/addon/services/resource-label.js
@@ -1,6 +1,7 @@
 import Service from '@ember/service';
 import fetch, { Headers } from 'fetch';
 import { getOwner } from '../utils/compat/get-owner';
+import { createUrlParams } from '../utils/url-params';
 const SHOEBOX_KEY = 'resource-label-cache';
 export default class ResourceLabelService extends Service {
   backend = '/';
@@ -48,14 +49,7 @@ export default class ResourceLabelService extends Service {
           ? baseUrl.slice(0, -1)
           : `${baseUrl || serviceBaseUrl}`;
 
-      // Fallback for URLSearchParams in FastBoot environment
-      let params;
-      if (typeof URLSearchParams !== 'undefined') {
-        params = new URLSearchParams({ term: uri });
-      } else {
-        // Manual query string construction for FastBoot
-        params = `term=${encodeURIComponent(uri)}`;
-      }
+      const params = createUrlParams({ term: uri });
 
       const fetchUrl = `${baseUrl}/resource-labels/info?${params}`;
 

--- a/addon/utils/fetch-uri-info.js
+++ b/addon/utils/fetch-uri-info.js
@@ -9,9 +9,15 @@ export default async function fetchUriInfo(
   // serviceBaseUrl is only useful when the service is running somewhere separate from the frontend
   // it can also be useful if the frontend and services are running on another path than '/'
 ) {
-
-  let baseUrl = fastboot?.isFastBoot ? (typeof window !== 'undefined' ? window.BACKEND_URL : serviceBaseUrl) : serviceBaseUrl;
-  baseUrl = baseUrl && baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : `${baseUrl || serviceBaseUrl}`;
+  let baseUrl = fastboot?.isFastBoot
+    ? typeof window !== 'undefined'
+      ? window.BACKEND_URL
+      : serviceBaseUrl
+    : serviceBaseUrl;
+  baseUrl =
+    baseUrl && baseUrl.endsWith('/')
+      ? baseUrl.slice(0, -1)
+      : `${baseUrl || serviceBaseUrl}`;
 
   // Fallback for URLSearchParams in FastBoot environment
   let params;

--- a/addon/utils/fetch-uri-info.js
+++ b/addon/utils/fetch-uri-info.js
@@ -10,14 +10,25 @@ export default async function fetchUriInfo(
   // it can also be useful if the frontend and services are running on another path than '/'
 ) {
 
-  let baseUrl = fastboot?.isFastBoot ? window.BACKEND_URL : serviceBaseUrl;
-  baseUrl = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : `${baseUrl}`;
+  let baseUrl = fastboot?.isFastBoot ? (typeof window !== 'undefined' ? window.BACKEND_URL : serviceBaseUrl) : serviceBaseUrl;
+  baseUrl = baseUrl && baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : `${baseUrl || serviceBaseUrl}`;
 
-  const params = new URLSearchParams({
-    subject,
-    pagenumber: number,
-    pagesize: size,
-  });
+  // Fallback for URLSearchParams in FastBoot environment
+  let params;
+  if (typeof URLSearchParams !== 'undefined') {
+    params = new URLSearchParams({
+      subject,
+      pagenumber: number,
+      pagesize: size,
+    });
+  } else {
+    // Manual query string construction for FastBoot
+    const queryParts = [];
+    if (subject) queryParts.push(`subject=${encodeURIComponent(subject)}`);
+    if (number) queryParts.push(`pagenumber=${encodeURIComponent(number)}`);
+    if (size) queryParts.push(`pagesize=${encodeURIComponent(size)}`);
+    params = queryParts.join('&');
+  }
 
   const url = `${baseUrl}/uri-info/${direction}?${params}`;
   const response = await fetch(url, {

--- a/addon/utils/fetch-uri-info.js
+++ b/addon/utils/fetch-uri-info.js
@@ -1,40 +1,40 @@
 import fetch, { Headers } from 'fetch';
-import buildUrl from 'build-url';
-
 export default async function fetchUriInfo(
   fastboot,
   subject,
   number,
   size,
   direction = 'direct',
+  serviceBaseUrl = '/',
+  // serviceBaseUrl is only useful when the service is running somewhere separate from the frontend
+  // it can also be useful if the frontend and services are running on another path than '/'
 ) {
-  const baseUrl = fastboot?.isFastBoot ? window.BACKEND_URL : '/';
 
-  const url = buildUrl(baseUrl, {
-    path: `uri-info/${direction}`,
-    queryParams: {
-      subject,
-      pageNumber: number,
-      pageSize: size,
-    },
+  let baseUrl = fastboot?.isFastBoot ? window.BACKEND_URL : serviceBaseUrl;
+  baseUrl = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : `${baseUrl}`;
+
+  const params = new URLSearchParams({
+    subject,
+    pagenumber: number,
+    pagesize: size,
   });
 
-  const response = await (
-    await fetch(url, {
-      headers: new Headers({
-        accept: 'application/vnd.api+json',
-        ...(fastboot?.isFastBoot
-          ? {
-              Cookie: fastboot.request?.headers.get('Cookie'),
-            }
-          : {}),
-      }),
-    })
-  ).json();
+  const url = `${baseUrl}/uri-info/${direction}?${params}`;
+  const response = await fetch(url, {
+    headers: new Headers({
+      accept: 'application/vnd.api+json',
+      ...(fastboot?.isFastBoot
+        ? {
+            Cookie: fastboot.request?.headers.get('Cookie'),
+          }
+        : {}),
+    }),
+  });
+  const body = await response.json();
 
   return {
     subject: subject,
-    triples: response.triples,
-    count: response.count,
+    triples: body.triples,
+    count: body.count,
   };
 }

--- a/addon/utils/fetch-uri-info.js
+++ b/addon/utils/fetch-uri-info.js
@@ -1,4 +1,5 @@
 import fetch, { Headers } from 'fetch';
+import { createUrlParams } from './url-params';
 export default async function fetchUriInfo(
   fastboot,
   subject,
@@ -19,22 +20,11 @@ export default async function fetchUriInfo(
       ? baseUrl.slice(0, -1)
       : `${baseUrl || serviceBaseUrl}`;
 
-  // Fallback for URLSearchParams in FastBoot environment
-  let params;
-  if (typeof URLSearchParams !== 'undefined') {
-    params = new URLSearchParams({
-      subject,
-      pagenumber: number,
-      pagesize: size,
-    });
-  } else {
-    // Manual query string construction for FastBoot
-    const queryParts = [];
-    if (subject) queryParts.push(`subject=${encodeURIComponent(subject)}`);
-    if (number) queryParts.push(`pagenumber=${encodeURIComponent(number)}`);
-    if (size) queryParts.push(`pagesize=${encodeURIComponent(size)}`);
-    params = queryParts.join('&');
-  }
+  const params = createUrlParams({
+    subject,
+    pagenumber: number,
+    pagesize: size,
+  });
 
   const url = `${baseUrl}/uri-info/${direction}?${params}`;
   const response = await fetch(url, {

--- a/addon/utils/url-params.js
+++ b/addon/utils/url-params.js
@@ -1,0 +1,21 @@
+/**
+ * Create URL search params string with FastBoot compatibility fallback
+ * @param {Object} params - Object with key-value pairs for URL parameters
+ * @returns {string} - URL encoded query string
+ */
+export function createUrlParams(params) {
+  if (typeof URLSearchParams !== 'undefined') {
+    return new URLSearchParams(params).toString();
+  } else {
+    // Manual query string construction for FastBoot environments without URLSearchParams global
+    const queryParts = [];
+    for (const [key, value] of Object.entries(params)) {
+      if (value !== undefined && value !== null) {
+        queryParts.push(
+          `${encodeURIComponent(key)}=${encodeURIComponent(value)}`,
+        );
+      }
+    }
+    return queryParts.join('&');
+  }
+}

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@embroider/macros": "^1.18.2",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
-    "build-url": "^6.0.1",
     "chalk": "^4.1.2",
     "ember-auto-import": "^2.8.1",
     "ember-cli-babel": "^8.2.0",
@@ -116,5 +115,8 @@
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"
+  },
+  "volta": {
+    "node": "20.19.4"
   }
 }

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -8,7 +8,11 @@ module.exports = function (environment) {
     locationType: 'history',
     metis: {
       routes: {},
-      baseUrl: 'EMBER_METIS_BASE_URL',
+      baseUrl: '/',
+      serviceBaseUrl: '/data',
+    },
+    fastboot: {
+      hostWhitelist: [/^localhost(:[0-9]*)?/, 'localhost', /^.*$/],
     },
     EmberENV: {
       EXTEND_PROTOTYPES: false,


### PR DESCRIPTION
serviceBaseUrl is only useful when the service is running somewhere separate from the frontend it can also be useful if the frontend and services are running on another path than '/'